### PR TITLE
Removed download-link from Font Awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Transform query strings through base64, html, url, and utf-8 encode/decode ~ *by
 
 ![Encode/Decode Workflow](http://f.cl.ly/items/2J3m1G1N46050I0E0w3n/alfred-encode.png)
 
-### [Font Awesome](https://github.com/ruedap/alfred2-font-awesome-workflow) (1.02) ~ [Download](http://zno.io/RcJ3)
+### [Font Awesome](https://github.com/ruedap/alfred2-font-awesome-workflow) (1.02)
 
 Search through [Font Awesome](http://fortawesome.github.io/Font-Awesome/) iconset ~ *by [@ruedap](https://github.com/ruedap/).*
 


### PR DESCRIPTION
Hi @zenorocha :-)
I want to provide the latest version, And I want to come to my repository.
So removed download-link. Okay?
