### PR TITLE
Update github workflow download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Generate fake data such as name, email address, credit card number, etc ~ *by [@
 
 <img width="594" alt="faker" src="https://cloud.githubusercontent.com/assets/398893/14360271/6d1ba944-fcaa-11e5-85dc-54045946f02e.png">
 
-### [GitHub](https://github.com/gharlan/alfred-github-workflow) (v1.6.0) ~ [Download](https://github.com/zenorocha/alfred-workflows/raw/master/github/github.alfredworkflow)
+### [GitHub](https://github.com/gharlan/alfred-github-workflow) (v1.6.2) ~ [Download v1.6.2](https://github.com/gharlan/alfred-github-workflow/releases/download/v1.6.2/github.alfredworkflow) ~ [Download latest](https://github.com/zenorocha/alfred-workflows/raw/master/github/github.alfredworkflow)
 
 Easily open [GitHub](https://github.com/) repositories and more in the browser ~ *by [@gharlan](https://github.com/gharlan/).*
 


### PR DESCRIPTION
When I downloaded with the current link, `gh > login` didn't work. Updated to use version-pinned link. But kept the "latest" link since that's how other links are